### PR TITLE
448 Add about field to user profile

### DIFF
--- a/app/controllers/web/bootcamp/wizard/profiles_controller.rb
+++ b/app/controllers/web/bootcamp/wizard/profiles_controller.rb
@@ -30,7 +30,8 @@ module Web
           params
             .require(:member_wizard_profile)
             .permit(:first_name, :last_name, :location,
-                    :timezone, :cv_url, :role, :primary_skill_id)
+                    :timezone, :cv_url, :role, :primary_skill_id,
+                    :about)
         end
 
         def policy_class

--- a/app/controllers/web/dashboard/profiles_controller.rb
+++ b/app/controllers/web/dashboard/profiles_controller.rb
@@ -32,7 +32,7 @@ module Web
 
       def profile_params
         params.require(:user)
-              .permit(:first_name, :last_name, :location, :timezone, :cv_url)
+              .permit(:first_name, :last_name, :location, :timezone, :cv_url, :about)
       end
     end
   end

--- a/app/controllers/web/idea/wizard/registrations_controller.rb
+++ b/app/controllers/web/idea/wizard/registrations_controller.rb
@@ -34,7 +34,7 @@ module Web
 
         def author_params
           params.require(:user)
-                .permit(:email, :first_name, :last_name, :location, :timezone, :password)
+                .permit(:email, :first_name, :last_name, :location, :timezone, :password, :about)
         end
       end
     end

--- a/app/forms/base_user_form.rb
+++ b/app/forms/base_user_form.rb
@@ -7,11 +7,13 @@ class BaseUserForm < BaseForm
   property :last_name
   property :location
   property :timezone
+  property :about
 
   validation do
     required(:first_name).filled
     required(:last_name).filled
     required(:timezone).filled
     required(:location).filled
+    required(:about).value(:filled?, min_size?: 150)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  password_digest :string
 #  name            :string
 #  admin           :boolean          default(FALSE)
+#  about           :string
 #
 
 require 'sorcery/model'

--- a/app/views/web/bootcamp/wizard/profiles/edit.html.haml
+++ b/app/views/web/bootcamp/wizard/profiles/edit.html.haml
@@ -10,4 +10,5 @@
   = f.input :cv_url
   = f.input :role, collection: new_member_role_options, include_blank: false
   = f.input :primary_skill_id, collection: Skill.active, include_blank: false
+  = f.input :about, as: :text
   = f.button :submit, t('bootcamp.profile.submit'), type: :submit, class: 'btn btn-lg btn-secondary'

--- a/app/views/web/dashboard/profiles/edit.html.haml
+++ b/app/views/web/dashboard/profiles/edit.html.haml
@@ -6,4 +6,5 @@
   = f.input :location
   = f.input :timezone, as: :time_zone
   = f.input :cv_url
+  = f.input :about
   = f.submit t('dashboard.profile.update.button')

--- a/app/views/web/dashboard/profiles/show.html.haml
+++ b/app/views/web/dashboard/profiles/show.html.haml
@@ -27,6 +27,9 @@
       %tr
         %td= t('dashboard.profile.registration_date')
         %td= human_date(@profile)
+      %tr
+        %td= t('dashboard.profile.about')
+        %td= @profile.about
 
 = link_to t('dashboard.profile.edit.button'), edit_dashboard_profile_url,
   class: 'btn btn-info'

--- a/app/views/web/idea/wizard/registrations/new.html.haml
+++ b/app/views/web/idea/wizard/registrations/new.html.haml
@@ -5,6 +5,7 @@
   = f.input :location
   = f.input :timezone, as: :time_zone
   = f.input :password
+  = f.input :about, as: :text
   = invisible_recaptcha_tags text: t('idea.registrations.submit'), class: 'btn btn-lg btn-secondary'
 
 = link_to t('idea.sessions.new.have_account'), new_idea_sessions_url

--- a/config/locales/dashboard/en.yml
+++ b/config/locales/dashboard/en.yml
@@ -133,6 +133,7 @@ en:
       test_tasks: Test Tasks
       users: Users management
     profile:
+      about: About
       cv_url: CV url
       edit:
         button: Edit

--- a/config/locales/dashboard/ru.yml
+++ b/config/locales/dashboard/ru.yml
@@ -133,6 +133,7 @@ ru:
       test_tasks: Тестовые задания
       users: Участники
     profile:
+      about: О себе
       cv_url: Резюме/Linkedin
       edit:
         button: Изменить

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -21,6 +21,7 @@ en:
           link: Link
       member_wizard_profile:
         edit:
+          about: About
           cv_url: CV url
           first_name: First name
           last_name: Last name

--- a/config/locales/simple_form.ru.yml
+++ b/config/locales/simple_form.ru.yml
@@ -21,6 +21,7 @@ ru:
           link: Ссылка
       member_wizard_profile:
         edit:
+          about: О себе
           cv_url: Резюме или Linkedin
           first_name: Имя
           last_name: Фамилия

--- a/db/migrate/20181224215628_add_about_to_users.rb
+++ b/db/migrate/20181224215628_add_about_to_users.rb
@@ -1,0 +1,5 @@
+class AddAboutToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :about, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_06_174224) do
+ActiveRecord::Schema.define(version: 2018_12_24_215628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2018_11_06_174224) do
     t.string "timezone"
     t.string "cv_url"
     t.integer "approver_id"
+    t.text "about"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/controllers/web/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/web/dashboard/profiles_controller_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe Web::Dashboard::ProfilesController do
           {
             first_name: 'Some new name',
             last_name:  'Some new last_name',
-            location:   'Some new location'
+            location:   'Some new location',
+            about: Faker::Lorem.characters(150)
           }
         end
 
@@ -97,7 +98,8 @@ RSpec.describe Web::Dashboard::ProfilesController do
         let(:params) do
           {
             last_name:  'Some new last_name',
-            email: 'some-new-email@gmail.com'
+            email: 'some-new-email@gmail.com',
+            about: Faker::Lorem.characters(150)
           }
         end
 

--- a/spec/controllers/web/idea/wizard/registrations_controller_spec.rb
+++ b/spec/controllers/web/idea/wizard/registrations_controller_spec.rb
@@ -51,7 +51,8 @@ describe Web::Idea::Wizard::RegistrationsController do
             first_name: 'John',
             last_name: 'Smith',
             location: 'Russia',
-            timezone: 'Europe/Moscow'
+            timezone: 'Europe/Moscow',
+            about: Faker::Lorem.characters(150)
           }
         }
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     location { Faker::Address.country }
     timezone { Faker::Address.time_zone }
     cv_url { Faker::Internet.url }
+    about { Faker::Lorem.characters(150) }
     password 'password'
     salt { 'ExqpVWiDcK2vGfeRjqTx' }
     crypted_password { Sorcery::CryptoProviders::BCrypt.encrypt('password', salt) }

--- a/spec/forms/author/registration_form_spec.rb
+++ b/spec/forms/author/registration_form_spec.rb
@@ -19,8 +19,27 @@ describe Author::RegistrationForm do
     it { expect(errors).to include :last_name }
     it { expect(errors).to include :location }
     it { expect(errors).to include :timezone }
+    it { expect(errors).to include :about }
 
     it { is_expected.not_to be_valid }
+
+    context 'with short about' do
+      let(:params) do
+        {
+          email: 'user@givemepoc.org',
+          password: 'password',
+          first_name: 'John',
+          last_name: 'Smith',
+          location: 'Russia',
+          timezone: 'Europe/Moscow',
+          about: 'About'
+        }
+      end
+
+      it { expect(errors).to include :about }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 
   context 'valid params' do
@@ -31,7 +50,8 @@ describe Author::RegistrationForm do
         first_name: 'John',
         last_name: 'Smith',
         location: 'Russia',
-        timezone: 'Europe/Moscow'
+        timezone: 'Europe/Moscow',
+        about: Faker::Lorem.characters(150)
       }
     end
 
@@ -41,6 +61,7 @@ describe Author::RegistrationForm do
     it { expect(errors).not_to include :last_name }
     it { expect(errors).not_to include :location }
     it { expect(errors).not_to include :timezone }
+    it { expect(errors).not_to include :about }
 
     it { is_expected.to be_valid }
   end

--- a/spec/forms/member/profile_form_spec.rb
+++ b/spec/forms/member/profile_form_spec.rb
@@ -16,7 +16,8 @@ describe Member::ProfileForm do
         last_name: 'Smith',
         location: 'Russia',
         timezone: 'Europe/Moscow',
-        cv_url: 'https://google.com'
+        cv_url: 'https://google.com',
+        about: Faker::Lorem.characters(150)
       }
     end
 
@@ -25,6 +26,7 @@ describe Member::ProfileForm do
     it { expect(errors).not_to include :location }
     it { expect(errors).not_to include :timezone }
     it { expect(errors).not_to include :cv_url }
+    it { expect(errors).not_to include :about }
 
     it { is_expected.to be_valid }
   end
@@ -37,7 +39,25 @@ describe Member::ProfileForm do
     it { expect(errors).to include :location }
     it { expect(errors).to include :timezone }
     it { expect(errors).to include :cv_url }
+    it { expect(errors).to include :about }
 
     it { is_expected.not_to be_valid }
+
+    context 'with short about' do
+      let(:params) do
+        {
+          first_name: 'John',
+          last_name: 'Smith',
+          location: 'Russia',
+          timezone: 'Europe/Moscow',
+          cv_url: 'https://google.com',
+          about: 'About'
+        }
+      end
+
+      it { expect(errors).to include :about }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 end

--- a/spec/forms/member/update_user_form_spec.rb
+++ b/spec/forms/member/update_user_form_spec.rb
@@ -19,7 +19,8 @@ describe Member::UpdateUserForm do
         timezone: 'Europe/Moscow',
         cv_url: 'https://google.com',
         github: 'superuser',
-        primary_skill_id: 1
+        primary_skill_id: 1,
+        about: Faker::Lorem.characters(150)
       }
     end
 
@@ -31,6 +32,7 @@ describe Member::UpdateUserForm do
     it { expect(errors).not_to include :cv_url }
     it { expect(errors).not_to include :github }
     it { expect(errors).not_to include :primary_skill_id }
+    it { expect(errors).not_to include :about }
 
     it { is_expected.to be_valid }
   end
@@ -46,7 +48,27 @@ describe Member::UpdateUserForm do
     it { expect(errors).to include :cv_url }
     it { expect(errors).to include :github }
     it { expect(errors).to include :primary_skill_id }
+    it { expect(errors).to include :about }
 
     it { is_expected.not_to be_valid }
+
+    context 'with short about' do
+      let(:params) do
+        {
+          email: 'user@gmail.com',
+          first_name: 'John',
+          last_name: 'Smith',
+          location: 'Russia',
+          timezone: 'Europe/Moscow',
+          cv_url: 'https://google.com',
+          github: 'superuser',
+          primary_skill_id: 1,
+          about: Faker::Lorem.characters(15)
+        }
+      end
+      it { expect(errors).to include :about }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 end

--- a/spec/forms/member/wizard/profile_form_spec.rb
+++ b/spec/forms/member/wizard/profile_form_spec.rb
@@ -18,7 +18,8 @@ describe Member::Wizard::ProfileForm do
         timezone: 'Europe/Moscow',
         cv_url: 'https://google.com',
         role: 'mentor',
-        primary_skill_id: 1
+        primary_skill_id: 1,
+        about: Faker::Lorem.characters(150)
       }
     end
 
@@ -29,6 +30,7 @@ describe Member::Wizard::ProfileForm do
     it { expect(errors).not_to include :cv_url }
     it { expect(errors).not_to include :role }
     it { expect(errors).not_to include :primary_skill_id }
+    it { expect(errors).not_to include :about }
 
     it { is_expected.to be_valid }
   end
@@ -43,7 +45,26 @@ describe Member::Wizard::ProfileForm do
     it { expect(errors).to include :cv_url }
     it { expect(errors).to include :role }
     it { expect(errors).to include :primary_skill_id }
+    it { expect(errors).to include :about }
 
     it { is_expected.not_to be_valid }
+
+    context 'with short about' do
+      let(:params) do
+        {
+          first_name: 'John',
+          last_name: 'Smith',
+          location: 'Russia',
+          timezone: 'Europe/Moscow',
+          cv_url: 'https://google.com',
+          role: 'mentor',
+          primary_skill_id: 1,
+          about: Faker::Lorem.characters(15)
+        }
+      end
+      it { expect(errors).to include :about }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 end

--- a/spec/operations/ops/author/sign_up_spec.rb
+++ b/spec/operations/ops/author/sign_up_spec.rb
@@ -12,7 +12,8 @@ describe Ops::Author::SignUp do
           first_name: 'John',
           last_name: 'Smith',
           location: 'Russia',
-          timezone: 'Europe/Moscow'
+          timezone: 'Europe/Moscow',
+          about: Faker::Lorem.characters(150)
         }
       end
 

--- a/spec/operations/ops/member/complete_profile_spec.rb
+++ b/spec/operations/ops/member/complete_profile_spec.rb
@@ -9,6 +9,7 @@ describe Ops::Member::CompleteProfile do
     let(:user) { create(:user) }
     let(:skill) { create(:skill) }
     let(:role) { role_for(user: user, role_name: :member) }
+    let(:about) { Faker::Lorem.characters(150) }
     let(:non_user_params) do
       {
         primary_skill_id: skill.id,


### PR DESCRIPTION
Issue #448

### Description

Add about field to user model

### Testing steps

Explain how to test your PR manually

* Step 1
* Step 2
* Step 3

### Features PR URL

[PR #ID](https://github.com/howtohireme/give-me-poc-features/pull/#ID)

### Checklist

Make sure that all steps a checked before the merge

- [ ] RSpec tests are passing on CI
- [ ] Cucumber features are passing localy
- [ ] `bin/cop -a` does not return any warnings
- [ ] Tested manually

### Screenshots

Provide screenshots of implemented functionality
![screenshot 2019-01-12 at 23 47 23](https://user-images.githubusercontent.com/4442395/51078318-7abb3100-16c4-11e9-9d4d-7a78e58a4f4c.png)
![screenshot 2019-01-12 at 23 50 35](https://user-images.githubusercontent.com/4442395/51078352-e30a1280-16c4-11e9-987a-b613cdf0f4a2.png)
![screenshot 2019-01-12 at 23 50 58](https://user-images.githubusercontent.com/4442395/51078356-f3ba8880-16c4-11e9-903a-592c6ee9708b.png)
![screenshot 2019-01-12 at 23 51 30](https://user-images.githubusercontent.com/4442395/51078358-0208a480-16c5-11e9-8375-8ed812799f23.png)

