### PR TITLE
Update link from symbiod.org to www.symbiod.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ If you want to take part in the project as developer then [this document](https:
 
 If you want to take part as designer of manager don't hesitate to drop us an [email](mailto:opensource@howtohireme.ru).
 
-And don't forget to sign up at [symbiod.org](http://symbiod.org) ;)
+And don't forget to sign up at [www.symbiod.org](https://www.symbiod.org) ;)


### PR DESCRIPTION
Update the link from symbiod.org to www.symbiod.org because symbiod.org don't redirect to the project